### PR TITLE
Add Custodial Signing

### DIFF
--- a/utilities/appState.js
+++ b/utilities/appState.js
@@ -23,6 +23,9 @@ const initialState = {
   decodedTransactionPayload: "", // Decoded using @figmentio/slate or multi-chain-signer-sdk
   signedTransactionPayload: "", // Signed using @figmentio/slate or multi-chain-signer-sdk
   unsignedDelegateTransactionPayload: "", // Used for Solana delegate transaction
+  unsignedSigningPayload: "", // Used for custodial signing of transactions
+  decodedSigningPayload: "", // Used for custodial signing of transactions
+  signedSigningPayload: "", // Used for custodial signing of transactions
   validatorAddress: "", // Store the validator address for verification during decode/sign
   delegateAmount: "", // Store the delegation amount for verification during decode/sign
   stepCompleted: 0, // Which step has been completed


### PR DESCRIPTION
- Adds an extra portion to the Decode & Sign Payloads step regarding custodial signing with the Fireblocks API
  - This is a draft of potential functionality. If it becomes possible to add Fireblocks API calls to this app, this will enable that functionality without disrupting the existing flow.
  
<img width="2160" alt="Screen Shot 2023-03-02 at 4 53 30 PM" src="https://user-images.githubusercontent.com/2707197/222592750-04ccc435-25c7-4a06-bb60-66bf44a59558.png">

 
<img width="2160" alt="Screen Shot 2023-03-02 at 4 53 36 PM" src="https://user-images.githubusercontent.com/2707197/222592788-6fad51e8-191d-4711-8753-5da95e43ec59.png">
